### PR TITLE
COM-238 Update travis to force grunt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,11 +39,11 @@ addons:
     
 deploy:
   - provider: script
-    script: ssh bahmni@cmr-dev.jembi.org 'cd ~/git/cameroon-openmrs-module-bahmniapps;git reset --hard;git checkout dev;git pull;cd ui;grunt'
+    script: ssh bahmni@cmr-dev.jembi.org 'cd ~/git/cameroon-openmrs-module-bahmniapps;git reset --hard;git checkout dev;git pull;cd ui;grunt --force'
     on:
       branch: dev
   - provider: script
-    script: ssh bahmni@cmr-staging.jembi.org 'cd ~/git/cameroon-openmrs-module-bahmniapps;git reset --hard;git checkout staging;git pull;cd ui;grunt'
+    script: ssh bahmni@cmr-staging.jembi.org 'cd ~/git/cameroon-openmrs-module-bahmniapps;git reset --hard;git checkout staging;git pull;cd ui;grunt --force'
     on:
       branch: staging
 


### PR DESCRIPTION
Travis was getting a warning when running grunt and was failing the build. Using grunt --force to ignore the warning.