### PR TITLE
COM-234 Update total quantity calculation for orders

### DIFF
--- a/ui/app/clinical/common/models/drugOrderViewModel.js
+++ b/ui/app/clinical/common/models/drugOrderViewModel.js
@@ -396,10 +396,15 @@ Bahmni.Clinical.DrugOrderViewModel = function (config, proto, encounterDate) {
     };
 
     this.calculateDurationInDays = function () {
-        var durationUnitFromConfig = _.find(durationUnits, function (unit) {
-            return unit.name === self.durationUnit;
-        });
-        self.durationInDays = self.duration ? self.duration * (durationUnitFromConfig && durationUnitFromConfig.factor || 1) : Number.NaN;
+        if (self.durationUnit === "Month(s)") {
+            var endDate = Bahmni.Common.Util.DateUtil.addMonths(self.effectiveStartDate, self.duration);
+            self.durationInDays = self.duration ? Bahmni.Common.Util.DateUtil.diffInDaysRegardlessOfTime(self.effectiveStartDate, endDate) : Number.NaN;
+        } else {
+            var durationUnitFromConfig = _.find(durationUnits, function (unit) {
+                return unit.name === self.durationUnit;
+            });
+            self.durationInDays = self.duration ? self.duration * (durationUnitFromConfig && durationUnitFromConfig.factor || 1) : Number.NaN;
+        }
     };
 
     var quantityUnitsFrom = function (doseUnit) {

--- a/ui/test/unit/clinical/models/drugOrderViewModel.spec.js
+++ b/ui/test/unit/clinical/models/drugOrderViewModel.spec.js
@@ -387,7 +387,7 @@ describe("drugOrderViewModel", function () {
 
             treatment.durationUnit = "Month(s)"
             treatment.calculateDurationInDays();
-            expect(treatment.durationInDays).toBe(180);
+            expect(treatment.durationInDays).toBe(184);
 
             treatment.durationUnit = "Day(s)"
             treatment.calculateDurationInDays();


### PR DESCRIPTION
For unit duration month, it was using 30 days instead of considering different month lengths. This was updated to consider the start date.