### PR TITLE
COM-468 Translate the 'chief complaint' field from history form

### DIFF
--- a/ui/app/common/concept-set/models/conceptSetObservation.js
+++ b/ui/app/common/concept-set/models/conceptSetObservation.js
@@ -39,6 +39,9 @@ Bahmni.ConceptSet.Observation = function (observation, savedObs, conceptUIConfig
                     savedObs.value['displayString'] = (savedObs.value.shortName ? savedObs.value.shortName : savedObs.value.name);
                 }
             }
+            if (savedObs && savedObs.value && savedObs.value.name && savedObs && savedObs.valueAsString) {
+                savedObs.value.name = savedObs.valueAsString;
+            }
             return savedObs ? savedObs.value : undefined;
         },
         set: function (newValue) {

--- a/ui/app/common/ui-helper/directives/conceptAutocomplete.js
+++ b/ui/app/common/ui-helper/directives/conceptAutocomplete.js
@@ -11,11 +11,11 @@
             });
         }
         return {
-            label: matchingName ? matchingName + " => " + conceptName : conceptName,
-            value: conceptName,
+            label: concept.displayString,
+            value: concept.displayString,
             concept: concept,
             uuid: concept.uuid,
-            name: conceptName
+            name: concept.displayString
         };
     };
 


### PR DESCRIPTION
Updates the auto-complete component that captures coded observations to translate the options in the drop-down options. This is the component used by the 'chief complaint' field in the history and exam form.

Jira ticket: https://jembiprojects.jira.com/browse/COM-468