### PR TITLE
COM-643 Sort the program workflow states

### DIFF
--- a/ui/app/common/uicontrols/programmanagement/controllers/manageProgramController.js
+++ b/ui/app/common/uicontrols/programmanagement/controllers/manageProgramController.js
@@ -246,6 +246,15 @@ angular.module('bahmni.common.uicontrols.programmanagment')
                 if (program && program.allWorkflows && program.allWorkflows.length && program.allWorkflows[0].states.length) {
                     states = program.allWorkflows[0].states;
                 }
+                states.sort(function (record1, record2) {
+                    if (record1.concept && record2.concept && record1.concept.display > record2.concept.display) {
+                        return 1;
+                    } else if (record1.concept && record2.concept && record1.concept.display < record2.concept.display) {
+                        return -1;
+                    } else {
+                        return 0;
+                    }
+                });
                 return states;
             };
 


### PR DESCRIPTION
The workflow states for the defaulter program are not sorted correctly; the states do not keep their order of creation (from the initializer module). This issue happens only for the defaulter program. The current fix sort the states at the UI side on alphabetical order; this fix is temporary and won't work if we need to sort the states differently (i.e. not in alphabetical order like currently).