### PR TITLE
COM-921 Clear the field 'other outcome' when the outcome field changes

### DIFF
--- a/ui/app/common/uicontrols/programmanagement/controllers/manageProgramController.js
+++ b/ui/app/common/uicontrols/programmanagement/controllers/manageProgramController.js
@@ -127,6 +127,12 @@ angular.module('bahmni.common.uicontrols.programmanagment')
                 return !_.isEmpty($scope.endedPrograms);
             };
 
+            $scope.programOutcomeChanged = function (_value) {
+                if (_value) {
+                    _value.PROGRAM_MANAGEMENT_OTHER_PROGRAM_OUTCOME = "";
+                }
+            };
+
             $scope.enrollPatient = function () {
                 if (!isProgramSelected()) {
                     messagingService.showMessage("error", "PROGRAM_MANAGEMENT_SELECT_PROGRAM_MESSAGE_KEY");

--- a/ui/app/common/uicontrols/programmanagement/views/programRow.html
+++ b/ui/app/common/uicontrols/programmanagement/views/programRow.html
@@ -60,6 +60,7 @@
                 </div>
                 <div class="field-value">
                     <select ng-model="patientProgram.outcomeData"
+                            ng-change="programOutcomeChanged(patientProgram.patientProgramAttributes)"
                             ng-options="outcomeSelected.names[0].display for outcomeSelected in ::patientProgram.program.outcomesConcept.setMembers">
                         <option value="">{{::'PROGRAM_MANAGEMENT_LABEL_CHOOSE_OUTCOME' | translate}}</option>
                     </select>


### PR DESCRIPTION
To prevent a value previously captured in 'other outcome' to be saved in the database when the outcome changes.
Jira ticket: https://jembiprojects.jira.com/browse/COM-921